### PR TITLE
chore: enforce semantic PR title

### DIFF
--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -1,0 +1,18 @@
+name: Semantic PR title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  semantic-pr-title:
+    name: Semantic PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Now that's we're using [semantic-release](https://github.com/valora-inc/logging/pull/5) it's important PR titles follow the convention.

https://github.com/marketplace/actions/semantic-pull-request is a simple solution for this.

We should probably add it to https://github.com/valora-inc/typescript-app-starter too.