### PR TITLE
feat(middleware): add Cloud Function name to the request path in Logs Explorer

### DIFF
--- a/src/logging.test.ts
+++ b/src/logging.test.ts
@@ -302,7 +302,7 @@ describe('logging middleware', () => {
         "hostname": Any<String>,
         "httpRequest": {
           "requestMethod": "POST",
-          "requestUrl": "/?anotherPhone=%2B123456XXXX",
+          "requestUrl": "/testLogger/?anotherPhone=%2B123456XXXX",
           "responseSize": 16,
           "status": 200,
         },

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -144,7 +144,8 @@ export function createLoggingMiddleware({
                 httpRequest: {
                   ...httpRequest,
                   // Add the Cloud Function name to the path so it's easier to see which function was called in Logs Explorer
-                  // By default it only shows `/?${query}`
+                  // By default it only shows `/?${query}` and hides the function name (and execution id) pills
+                  // from the summary line which are otherwise present when httpRequest is not set
                   requestUrl:
                     requestUrl?.startsWith('/') &&
                     !requestUrl.startsWith(`/${cloudFunctionName}`)


### PR DESCRIPTION
Right now it looks like this:
<img width="735" alt="Screenshot 2022-10-31 at 15 03 44" src="https://user-images.githubusercontent.com/57791/199026564-79474ce1-06ec-41ec-a7bd-c980765e70d7.png">

With this change, the path will be `/testLogger/?test=yep` to avoid confusion when looking at logs.
