### PR TITLE
chore: allow more node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Valora Inc",
   "license": "Apache-2.0",
   "engines": {
-    "node": "^16"
+    "node": ">=16"
   },
   "files": [
     "dist"


### PR DESCRIPTION
node 18 is LTS now, updating to allow using this package in any version >=16