### PR TITLE
fix: use new link for the github build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub License](https://img.shields.io/github/license/valora-inc/logging?color=blue)](https://github.com/valora-inc/logging/blob/main/LICENSE)
 [![npm version](https://img.shields.io/npm/v/@valora/logging.svg)](https://www.npmjs.com/package/@valora/logging)
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/valora-inc/logging/Workflow/main)](https://github.com/valora-inc/logging/actions/workflows/workflow.yaml?query=branch%3Amain)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/valora-inc/logging/.github/workflows/workflow.yaml?branch=main)](https://github.com/valora-inc/logging/actions/workflows/workflow.yaml?query=branch%3Amain)
 [![Codecov](https://img.shields.io/codecov/c/github/valora-inc/logging)](https://codecov.io/gh/valora-inc/logging)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/valora-inc/logging#contributing)
 


### PR DESCRIPTION
See https://github.com/badges/shields/issues/8671