### PR TITLE
fix: convert `BigInt` values to strings

### DIFF
--- a/src/logging.test.ts
+++ b/src/logging.test.ts
@@ -177,6 +177,37 @@ describe('logger', () => {
     `,
     )
   })
+
+  it('should transfrom BigInt values to strings', async () => {
+    const logger = createLogger()
+    logger.info(
+      { a: { b: { c: 10n, d: 'Text' }, e: 20n }, f: 30n },
+      'I have BigInt',
+    )
+    expect(spyLoggerEmit).toHaveBeenCalledTimes(1)
+    expect(spyLoggerEmit.mock.calls[0][0]).toMatchInlineSnapshot(
+      DEFAULT_PROPERTY_MATCHER,
+      `
+      {
+        "a": {
+          "b": {
+            "c": "10",
+            "d": "Text",
+          },
+          "e": "20",
+        },
+        "f": "30",
+        "hostname": Any<String>,
+        "level": 30,
+        "msg": "I have BigInt",
+        "name": "default",
+        "pid": Any<Number>,
+        "time": 2022-10-18T23:36:07.071Z,
+        "v": 0,
+      }
+    `,
+    )
+  })
 })
 
 describe('logging middleware', () => {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -89,9 +89,10 @@ export function createLogger({
       // This makes the redact action stable when calling `logger.info({ req })` multiple times
       // i.e. the original `req` object is not mutated
       // This assumes all fields are serializable, which they should at this point
+      // BigInt values are transformed to strings during serialization
       Object.assign(
         logRecord,
-        redact(JSON.parse(globalReplace(JSON.stringify(rest)))),
+        redact(JSON.parse(globalReplace(JSON.stringify(rest, bigIntReplacer)))),
       )
 
       // Call the original _emit
@@ -248,4 +249,8 @@ export function createDetailedRequestSerializers() {
   }
 
   return serializers
+}
+
+function bigIntReplacer(_: unknown, value: unknown) {
+  return typeof value === 'bigint' ? value.toString() : value
 }


### PR DESCRIPTION
If an object being logged contains `BigInt` values, JSON serialization will throw a `TypeError`.

We can explicitly convert those values to strings.